### PR TITLE
pc - add and/or improve ApiParam documentation

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import io.swagger.annotations.ApiParam;
 
 @RestController
 @RequestMapping("/api/sections")
@@ -31,18 +32,18 @@ public class UCSBSectionsController {
     UCSBCurriculumService ucsbCurriculumService;
 
     @GetMapping(value = "/basicsearch", produces = "application/json")
-    public ResponseEntity<String> basicsearch(@RequestParam String qtr, @RequestParam String dept,
-            @RequestParam String level) throws JsonProcessingException {
-
+    public ResponseEntity<String> basicsearch(
+            @ApiParam(name = "qtr", type = "String", value = "quarter in yyyyq format (e.g. 20221 for W22)", example = "20221", required = true) @RequestParam String qtr,
+            @ApiParam(name = "dept", type = "String", value = "subject area, e.g. CMPSC for Computer Science", example = "CMPSC", required = true) @RequestParam String dept,
+            @ApiParam(name = "level", type = "String", value = "level, 1 character code: 'G'raduate or 'U'ndergraduate, 'L' for ugrad lower div, 'S' for ugrad upper div, A for All", example = "U", required = true) @RequestParam String level)
+            throws JsonProcessingException {
         String body = ucsbCurriculumService.getSectionJSON(dept, qtr, level);
-
-
         return ResponseEntity.ok().body(body);
-    }      
+    }
 
     @GetMapping(value = "/sectionsearch", produces = "application/json")
     public ResponseEntity<String> sectionsearch(@RequestParam String qtr, @RequestParam String enrollCode) {
-            
+
         String body = ucsbCurriculumService.getSection(enrollCode, qtr);
 
         return ResponseEntity.ok().body(body);

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSubjectsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSubjectsController.java
@@ -50,21 +50,21 @@ public class UCSBSubjectsController extends ApiController {
     @ApiOperation(value = "Load subjects into database from UCSB API")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/load")
-    public List<UCSBSubject> loadSubjects() throws JsonProcessingException{
-       
+    public List<UCSBSubject> loadSubjects() throws JsonProcessingException {
+
         List<UCSBSubject> subjects = ucsbSubjectsService.get();
-        
+
         List<UCSBSubject> savedSubjects = new ArrayList<UCSBSubject>();
 
-        subjects.forEach((ucsbSubject)->{
+        subjects.forEach((ucsbSubject) -> {
             try {
-              subjectRepository.save(ucsbSubject);
-              savedSubjects.add(ucsbSubject);
+                subjectRepository.save(ucsbSubject);
+                savedSubjects.add(ucsbSubject);
             } catch (DuplicateKeyException dke) {
                 log.info("Skipping duplicate entity %s".formatted(ucsbSubject.getSubjectCode()));
             }
         });
-        log.info("subjects={}",subjects);
+        log.info("subjects={}", subjects);
         return savedSubjects;
     }
 
@@ -72,7 +72,8 @@ public class UCSBSubjectsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER') || hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public UCSBSubject getSubjectById(
-            @ApiParam("subjectCode") @RequestParam String subjectCode) throws JsonProcessingException {
+            @ApiParam(name = "subjectCode", type = "String", value = "code for subject area, e.g. CMPSC for Computer Science", example = "CMPSC", required = true)
+            @RequestParam String subjectCode) throws JsonProcessingException {
 
         UCSBSubject subject = subjectRepository.findById(subjectCode)
                 .orElseThrow(() -> new EntityNotFoundException(UCSBSubject.class, subjectCode));
@@ -84,7 +85,8 @@ public class UCSBSubjectsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
     public Object deleteSubject(
-            @ApiParam("subjectCode") @RequestParam String subjectCode) {
+            @ApiParam(name = "subjectCode", type = "String", value = "code for subject area, e.g. CMPSC for Computer Science", example = "CMPSC", required = true)
+            @RequestParam String subjectCode) {
 
         UCSBSubject subject = subjectRepository.findById(subjectCode)
                 .orElseThrow(() -> new EntityNotFoundException(UCSBSubject.class, subjectCode));


### PR DESCRIPTION
In this PR, we illustrate ways of using the `@ApiParam` annotation to improve the quality of the Swagger API documentation.

For example, we change:

```
@RequestParam String qtr, @RequestParam String dept, @RequestParam String 
```

To:

```
            @ApiParam(name = "qtr", type = "String", value = "quarter in yyyyq format (e.g. 20221 for W22)", example = "20221", required = true)
            @RequestParam String qtr,
            @ApiParam(name = "dept", type = "String", value = "subject area, e.g. CMPSC for Computer Science", example = "CMPSC", required = true)
            @RequestParam String dept,
            @ApiParam(name = "level", type = "String", value = "level, 1 character code: 'G'raduate or 'U'ndergraduate, 'L' for ugrad lower div, 'S' for ugrad upper div, A for All", example = "U", required = true)
            @RequestParam String level)
```

# Before

Notice that there is little explanation of each parameter.  It's an "if you know, you know" type of situation.  But if you don't know, it can be frustrating for newcomers to the code base.

<img width="865" alt="image" src="https://github.com/ucsb-cs156-s23/proj-courses-staff/assets/1119017/329c92c3-685a-495d-95cc-19cea051d525">


# After

Notice that there is more explanation of each parameter, as well as sample default values to try.

<img width="1196" alt="image" src="https://github.com/ucsb-cs156-s23/proj-courses-staff/assets/1119017/ab2f58d9-09b2-4155-9307-76971329d0ae">


# More info
For more info, see: https://www.baeldung.com/swagger-apiparam-vs-apimodelproperty#apiparam